### PR TITLE
为E01002-E01013规则添加示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The Web Code Quality Tool, including both front-end (HTML, CSS, JavaScript) and 
 - E01002. DOCTYPE for HTML5 should be "&lt;DOCTYPE html&gt;" (HTML5的文档类型必须是"&lt;DOCTYPE html&gt;")
 - E01003. invalid tag (不可使用非法标签)
 - E01004. deprecated tag (不可使用废弃标签)
-- E01005. tag must be paired (标签必须成对)
+- E01005. non-selfclose tag must be paired (双标签必须成对)
 - E01006. invalid attribute (不可使用非法属性)
 - E01007. deprecared attribute (不能使用废弃的属性)
 - E01008. required element missing (必须包含特定标签)

--- a/Rule.md
+++ b/Rule.md
@@ -69,3 +69,33 @@
 
 </html>
 ```
+
+### E01003. invalid tag (不可使用非法标签)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <p>AAA</p>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <invalidtag>AAA</invalidtag>
+  </body>
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -352,3 +352,31 @@
   </body>
 </html>
 ```
+
+### E01011. tag name must be in lowercase (标签名必须小写)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<HTML lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -8,7 +8,7 @@
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="zh-Hans">
   <head>
     <title>文档的标题</title>
   </head>
@@ -24,7 +24,7 @@
 
 ```html
 <!-- <!DOCTYPE html> -->
-<html>
+<html lang="zh-Hans">
   <head>
     <title>文档的标题</title>
   </head>
@@ -42,7 +42,7 @@
 
 ```html
 <!DOCTYPE html>
-<html>
+<html lang="zh-Hans">
   <head>
     <title>文档的标题</title>
   </head>
@@ -58,7 +58,7 @@
 
 ```html
 <!DOCTYPE html6>
-<html>
+<html lang="zh-Hans">
   <head>
     <title>文档的标题</title>
   </head>
@@ -278,7 +278,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title></title>
+    <title>Page Title</title>
   </head>
   <body>
   </body>
@@ -291,6 +291,34 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+### E01009. required attribute missing (必须包含特定属性)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Page Title</title>
   </head>
   <body>
   </body>

--- a/Rule.md
+++ b/Rule.md
@@ -105,7 +105,7 @@
 废弃标签包括
 
 ```html
-<centent>, <font>, <s>, <strike>, <b>, <i>, <tt>, <small>, <frame>, <acronym>, <big>, <u>, <isindex>, <basefont>, <dir>, <applet>, <style>
+<center>, <font>, <s>, <strike>, <b>, <i>, <tt>, <small>, <frame>, <acronym>, <big>, <u>, <isindex>, <basefont>, <dir>, <applet>, <style>
 ```
 
 正确：
@@ -147,7 +147,7 @@
     <title>Page Title</title>
   </head>
   <body>
-    <p>段落</p>
+    <p>段落</p><br>
   </body>
 </html>
 ```
@@ -162,6 +162,34 @@
   </head>
   <body>
     <p>段落
+  </body>
+</html>
+```
+
+### E01006. invalid attribute (不可使用非法属性)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title invalidattribute="oh">Page Title</title>
+  </head>
+  <body>
   </body>
 </html>
 ```

--- a/Rule.md
+++ b/Rule.md
@@ -193,3 +193,67 @@
   </body>
 </html>
 ```
+
+### E01007. deprecared attribute (不能使用废弃的属性)
+
+废弃属性包括
+
+| 属性 | 所属的元素 |
+| ---- | ---- |
+| manifest | html |
+| xmlns | html,title |
+| align | caption, iframe, img, input, object, legend, table, hr, div, h1, h2, h3, h4, h5, h6, p, col, colgroup, tbody, td, tfoot, th, thead and tr |
+| alink | body |
+| link | body |
+| vlink | body |
+| text | body |
+| background | body |
+| bgcolor | table, tr, td, th and body |
+| border | table and object, img|
+| char | col, colgroup, tbody, td, tfoot, th, thead and tr |
+| charoff | col, colgroup, tbody, td, tfoot, th, thead and tr |
+| compact | dl , ol and ul |
+| frame | table |
+| frameborder | iframe |
+| hspace | img and object |
+| nowrap | td and th|
+| rules | table |
+| type | li, ol and ul |
+| value | li |
+| valign | col, colgroup, tbody, td, tfoot, th, thead and tr |
+| width | hr, table, td, th, col, colgroup and pre |
+| accept | form |
+| vspace | img |
+| charset | a, link |
+| coords | a |
+| name | a |
+| rev | a, link |
+| shape |
+| target | link |
+| height | th, td |
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title style="font-size: 1rem">Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -135,3 +135,33 @@
   </body>
 </html>
 ```
+
+### E01005. non-selfclosed tag must be paired (双标签必须成对)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <p>段落</p>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <p>段落
+  </body>
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -380,3 +380,31 @@
   </body>
 </html>
 ```
+
+### E01012. attribute name must be in lowercase (属性名必须小写)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html LANG="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -35,3 +35,37 @@
 
 </html>
 ```
+
+### E01002. DOCTYPE for HTML5 should be "&lt;DOCTYPE html&gt;" (HTML5的文档类型必须是"&lt;DOCTYPE html&gt;")
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>文档的标题</title>
+  </head>
+
+  <body>
+    文档的内容......
+  </body>
+
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html6>
+<html>
+  <head>
+    <title>文档的标题</title>
+  </head>
+
+  <body>
+    文档的内容......
+  </body>
+
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -408,3 +408,31 @@
   </body>
 </html>
 ```
+
+### E01013. "title" element must not be empty (title标签不可为空)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+  </body>
+</html>
+```

--- a/Rule.md
+++ b/Rule.md
@@ -20,7 +20,7 @@
 </html>
 ```
 
-错误
+错误：
 
 ```html
 <!-- <!DOCTYPE html> -->
@@ -317,6 +317,34 @@
 ```html
 <!DOCTYPE html>
 <html>
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+### E01010. duplicated attribute (同一标签不可使用重复的属性)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en" lang="zh-Hans">
   <head>
     <title>Page Title</title>
   </head>

--- a/Rule.md
+++ b/Rule.md
@@ -138,6 +138,18 @@
 
 ### E01005. non-selfclosed tag must be paired (双标签必须成对)
 
+成对标签：
+
+```html
+<html>, <body>, <title>, <p>, <div>, <h1>~<h6>,<abbr>, <address>, <bdi>, <bdo>, <blockquote>, <cite>, <del>, <dfn>, <em>, <ins>, <kbd>, <meter>, <progress>, <rb>, <rtc>, <rp>, <rt>, <ruby>, <time>, <datalist>, <canvas>, <figcaption>, <figure>, <audio>, <source>, <video>, <nav>, <header>, <footer>, <section>, <article>, <aside>, <details>, <dialog>, <pre>, <q>, <samp>, <strong>, <sup>, <sub>, <var>, <form>, <textarea>, <button>, <select>, <option>, <optgroup>, <label>, <fieldset>, <legend>, <frameset>,<noframes>, <map>, <a>, <ul>, <ol>, <li>, <dl>, <dt>, <dd>, <menu>, <menuitem>, <span>, <head>, <script>, <noscript>, <object>, <table>, <th>, <td>, <tr>, <tbody>, <thead>, <tfoot>, <caption>, <col>, <colgroup>, <main>, <picture>, <template>, <data>, <code>
+```
+
+自闭合标签：
+
+```html
+<wbr>, <keygen>, <output>, <track>, <embed>, <input>, <iframe>, <img>, <area>, <link>, <meta>, <base>, <param>
+```
+
 正确：
 
 ```html
@@ -252,6 +264,33 @@
 <html lang="en">
   <head>
     <title style="font-size: 1rem">Page Title</title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+### E01008. required element missing (必须包含特定标签)
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title></title>
+  </head>
+  <body>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
   </head>
   <body>
   </body>

--- a/Rule.md
+++ b/Rule.md
@@ -99,3 +99,39 @@
   </body>
 </html>
 ```
+
+### E01004. deprecated tag (不可使用废弃标签)
+
+废弃标签包括
+
+```html
+<centent>, <font>, <s>, <strike>, <b>, <i>, <tt>, <small>, <frame>, <acronym>, <big>, <u>, <isindex>, <basefont>, <dir>, <applet>, <style>
+```
+
+正确：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <p>something</p>
+  </body>
+</html>
+```
+
+错误：
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Page Title</title>
+  </head>
+  <body>
+    <font>something</font>
+  </body>
+</html>
+```


### PR DESCRIPTION
- E01002. DOCTYPE for HTML5 should be "&lt;DOCTYPE html&gt;" (HTML5的文档类型必须是"&lt;DOCTYPE html&gt;")
- E01003. invalid tag (不可使用非法标签)
- E01004. deprecated tag (不可使用废弃标签)
- E01005. non-selfclose tag must be paired (双标签必须成对)
- E01006. invalid attribute (不可使用非法属性)
- E01007. deprecared attribute (不能使用废弃的属性)
- E01008. required element missing (必须包含特定标签)
- E01009. required attribute missing (必须包含特定属性)
- E01010. duplicated attribute (同一标签不可使用重复的属性)
- E01011. tag name must be in lowercase (标签名必须小写)
- E01012. attribute name must be in lowercase (属性名必须小写)
- E01013. "title" element must not be empty (title标签不可为空)
